### PR TITLE
xorg-xorgproto 2024.1: Rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,9 @@ source:
     - 0001-windows-fds-bits.patch  # [win]
 
 build:
-  number: 0
+  number: 1
+  run_exports:
+    - {{ pin_subpackage('xorg-xorgproto') }}
 
 requirements:
   build:
@@ -34,6 +36,36 @@ requirements:
     - {{ compiler('m2w64_c') }}  # [win]
   host:
     - xorg-util-macros
+  run_constrained:
+    - xorg-applewmproto <0.0.0a
+    - xorg-bigreqsproto <0.0.0a
+    - xorg-compositeproto <0.0.0a
+    - xorg-damageproto <0.0.0a
+    - xorg-dmxproto <0.0.0a
+    - xorg-dpmsproto <0.0.0a
+    - xorg-dri2proto <0.0.0a
+    - xorg-dri3proto <0.0.0a
+    - xorg-fixesproto <0.0.0a
+    - xorg-fontsproto <0.0.0a
+    - xorg-glproto <0.0.0a
+    - xorg-inputproto <0.0.0a
+    - xorg-kbproto <0.0.0a
+    - xorg-presentproto <0.0.0a
+    - xorg-randrproto <0.0.0a
+    - xorg-recordproto <0.0.0a
+    - xorg-renderproto <0.0.0a
+    - xorg-resourceproto <0.0.0a
+    - xorg-scrnsaverproto <0.0.0a
+    - xorg-videoproto <0.0.0a
+    - xorg-xcmiscproto <0.0.0a
+    - xorg-xextproto <0.0.0a
+    - xorg-xf86bigfontproto <0.0.0a
+    - xorg-xf86dgaproto <0.0.0a
+    - xorg-xf86driproto <0.0.0a
+    - xorg-xf86vidmodeproto <0.0.0a
+    - xorg-xineramaproto <0.0.0a
+    - xorg-xproto <0.0.0a
+    - xorg-xwaylandproto <0.0.0a
 
 test:
   commands:


### PR DESCRIPTION
**Destination channel:** main

### Links:

- [PKG-8112](https://anaconda.atlassian.net/browse/PKG-8112)

### Explanation of changes:

- Bump build number to `1`
- Add `run_exports`
- Add `run_constrained`

### Notes:

- See https://github.com/AnacondaRecipes/xorg-libx11-feedstock/pull/1#discussion_r2069382976

[PKG-8112]: https://anaconda.atlassian.net/browse/PKG-8112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ